### PR TITLE
Fix broken resource picker in the Page Architect

### DIFF
--- a/resources/views/livewire/resource-picker.blade.php
+++ b/resources/views/livewire/resource-picker.blade.php
@@ -6,7 +6,7 @@
     submit () {
         let parent = Livewire.all().find(component => component.name.includes('app.filament.resources'))
 
-        if (parent) {
+        if (parent && parent.$wire.$get('{{ $statePath }}') !== undefined) {
             parent.$wire.$set('{{ $statePath }}', this.state)
         }
 


### PR DESCRIPTION
When setting the parent state of the picker, it breaks because it can't find any property to set
This is the result of a breaking change in Livewire:
- https://github.com/livewire/livewire/releases/tag/v3.4.12
- https://github.com/livewire/livewire/commit/54dd265c17f7b5200627eb9690590e7cbbad1027#diff-e6c90be20d24065f607e649f4f4ac5014d93120b2527f0e4b27a724171e511ceR316-R320

This fix will check if the prop exists on the parent component before trying to set it